### PR TITLE
Bump node version to 16+ to support grafana 8.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
     "start" : "./run.sh"
   },
   "engines": {
-    "node" : "^14"
+    "node" : "^16"
   }
 }


### PR DESCRIPTION
We need to bump node version to support 8.5.2 (latest at that time)
source: https://github.com/grafana/grafana/blob/v8.5.2/package.json#L410